### PR TITLE
Fixed typo in module name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='1.5.0',
     author='James Cranwell-Ward',
     author_email='jcranwellward@unicef.org',
-    py_modules=['activtyinfo_client'],
+    py_modules=['activityinfo_client'],
     install_requires=['requests'],
     description='Simple python wrapper for ActivityInfo REST API'
 )


### PR DESCRIPTION
An import like `from activityinfo_client import ActivityInfoClient` doesn't work because of a typo in the module name.